### PR TITLE
feat: add suport for image-stream-inf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,6 +814,7 @@ checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 name = "hls-manifest-viewer"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "bitter",
  "console_error_panic_hook",
  "console_log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ widevine-proto = "0.1.0"
 quick-xml = "0.38"
 hex-literal = "1.0.0"
 bitter = "0.8"
+base64 = "0.22"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/index.html
+++ b/index.html
@@ -272,6 +272,10 @@
       max-width: 60%;
     }
 
+    .viewer-supplemental.image-view {
+      max-width: 100%;
+    }
+
     .viewer-supplemental.isobmff-view {
       display: flex;
       min-width: 30%;

--- a/src/components/viewer/image.rs
+++ b/src/components/viewer/image.rs
@@ -1,0 +1,15 @@
+use super::{IMAGE_VIEW_CLASS, SUPPLEMENTAL_VIEW_CLASS};
+use base64::prelude::*;
+use leptos::prelude::*;
+
+#[component]
+pub fn ImageViewer(contents: Vec<u8>, content_type: String) -> impl IntoView {
+    view! {
+        <div class=SUPPLEMENTAL_VIEW_CLASS>
+            <img
+                class=IMAGE_VIEW_CLASS
+                src=format!("data:{content_type};base64,{}", BASE64_STANDARD.encode(&contents))
+            />
+        </div>
+    }
+}

--- a/src/components/viewer/mod.rs
+++ b/src/components/viewer/mod.rs
@@ -1,6 +1,7 @@
 mod asset_list;
 mod daterange_schedule;
 mod error;
+mod image;
 mod isobmff;
 mod loading;
 mod playlist;
@@ -10,16 +11,17 @@ mod scte35;
 use crate::{
     components::viewer::daterange_schedule::DaterangeScheduleView,
     utils::{
-        network::{FetchError, FetchTextResponse, RequestRange, fetch_array_buffer, fetch_text},
+        network::{fetch_array_buffer, fetch_text, FetchError, FetchTextResponse, RequestRange},
         query_codec::{
             AssetListContext, DaterangeScheduleContext, MediaSegmentContext, PartSegmentContext,
             SupplementalViewQueryContext,
         },
-        response::{SegmentType, determine_segment_type},
+        response::{determine_segment_type, SegmentType},
     },
 };
 use asset_list::AssetListView;
 use error::ViewerError;
+use image::ImageViewer;
 use isobmff::IsobmffViewer;
 use leptos::{either::Either, prelude::*};
 pub use loading::ViewerLoading;
@@ -32,6 +34,7 @@ const VIEWER_CLASS: &str = "viewer-content";
 const MAIN_VIEW_CLASS: &str = "viewer-main";
 const SUPPLEMENTAL_VIEW_CLASS: &str = "viewer-supplemental supplemental-active";
 const ISOBMFF_VIEW_CLASS: &str = "viewer-supplemental isobmff-view supplemental-active";
+const IMAGE_VIEW_CLASS: &str = "viewer-supplemental image-view supplemental-active";
 const MAIN_VIEW_WITH_SUPPLEMENTAL_CLASS: &str = "viewer-main supplemental-active";
 const ERROR_CONTAINER_CLASS: &str = "error-container";
 const ERROR_CLASS: &str = "error";
@@ -279,6 +282,26 @@ fn SupplementalSegmentView(segment_url: String, byterange: Option<RequestRange>)
                                         }
                                         SegmentType::Mp4 => {
                                             view! { <IsobmffViewer data=r.response_body /> }.into_any()
+                                        }
+                                        SegmentType::Image => {
+                                            if let Some(content_type) = &r.content_type {
+                                                view! {
+                                                    <ImageViewer
+                                                        contents=r.response_body
+                                                        content_type=content_type.clone()
+                                                    />
+                                                }
+                                                    .into_any()
+                                            } else {
+                                                // This case shuoldn't happen since we already
+                                                // checked the content type when determining the
+                                                // segment type.
+                                                view! {
+                                                    <ViewerError error="Error: unknown content type for image segment"
+                                                        .to_string() />
+                                                }
+                                                    .into_any()
+                                            }
                                         }
                                         SegmentType::Unknown => {
                                             view! {

--- a/src/components/viewer/playlist.rs
+++ b/src/components/viewer/playlist.rs
@@ -170,6 +170,7 @@ fn try_get_lines(
                     Some(TagName::Map) => x_map(&tag, &mut parsing_state),
                     Some(TagName::Part) => x_part(&tag, &mut parsing_state),
                     Some(TagName::Daterange) => x_daterange(&tag, &mut parsing_state),
+                    None if tag.name() == "-X-IMAGE-STREAM-INF" => playlist_uri_tag(&tag, &mut parsing_state),
                     _ => parsing_state.lines.push(
                         view! { <p class=TAG_CLASS>{String::from_utf8_lossy(tag.as_bytes())}</p> }
                             .into_any(),

--- a/src/utils/response.rs
+++ b/src/utils/response.rs
@@ -9,6 +9,7 @@ use crate::utils::network::FetchArrayBufferResonse;
 pub enum SegmentType {
     WebVtt,
     Mp4,
+    Image,
     Unknown,
 }
 
@@ -31,6 +32,7 @@ fn probe_content_type(content_type: &Option<String>) -> Option<SegmentType> {
         "application/mp4" => Some(SegmentType::Mp4), // IMSC1
         "text/vtt" => Some(SegmentType::WebVtt),
         "text/plain" => Some(SegmentType::WebVtt),
+        t if t.starts_with("image/") => Some(SegmentType::Image),
         _ => None,
     }
 }


### PR DESCRIPTION
The EXT-X-IMAGE-STREAM-INF is defined as a custom extension to HLS. The definition can be found on this Roku developer page: https://developer.roku.com/dev/docs/hls-and-dash

Important to us is that it acts like EXT-X-I-FRAME-STREAM-INF in that it has a URI attribute that points to a playlist. The segments of that playlist are then just image files. The playlist will contain the EXT-X-IMAGES-ONLY tag. I _could_ use this tag in the playlist to define a new segment context. Instead I just kept it as a segment and then infer that the response is an image based on whether the content type starts with `image/`.

In retrospect, perhaps relying on the images only tag is better, as I could avoid pulling in the base64 dependency. For now this is working, but I may change it.

I did take a look into changing it; however, the limitation I run into is application of range requests that may be required based on the `EXT-X-BYTERANGE` tag. I have doubts whether anyone would ever use ranges with `EXT-X-IMAGES-ONLY`, but it is technically valid, and so I should support it. But, if I do support it, there is no native HTML5 attribute for applying the range to the `src` on the `img`, and so I'd need to make the request and base64 encode the data anyway in that case, which also means I need the library anyway. So I'm just leaving it the way it is.